### PR TITLE
Initial record

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,103 @@
+
+# Created by https://www.gitignore.io/api/python,pycharm
+
+### PyCharm ###
+.idea/
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# dotenv
+.env
+
+# virtualenv
+.venv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+
+# Rope project settings
+.ropeproject
+
+# End of https://www.gitignore.io/api/python,pycharm

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: python
+python:
+  - "2.7"
+# command to install dependencies
+install: "pip install -r requirements.txt"
+# command to run tests
+script: python -m unittest discover

--- a/pycoda/__init__.py
+++ b/pycoda/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals

--- a/pycoda/fields.py
+++ b/pycoda/fields.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals

--- a/pycoda/fields.py
+++ b/pycoda/fields.py
@@ -90,3 +90,30 @@ class ZeroesField(StringField):
     def loads(self, string):
         super(ZeroesField, self).loads(string)
 
+
+class NumericField(StringField):
+    def __init__(self, position, length, value=None, tag=None,
+                 pad='', align='<', head='', tail=''):
+        super(NumericField, self).__init__(position, length,
+                                           value=value, tag=tag,
+                                           pad=pad, align=align)
+        self.head = head
+        self.tail = tail
+
+    def _regex(self):
+        length = self.length - len(self.head) - len(self.tail)
+        return r'^({self.head})?(?P<value>[\d\s]{{{length}}})({self.tail})?$'.format(self=self, length=length)
+
+    def _parse(self, string):
+        return super(NumericField, self)._parse(string)
+
+    def dumps(self):
+        value = self.value if self.value else 0
+        length = self.length - len(self.head) - len(self.tail)
+        dump_format = '{value:{self.pad}{self.align}{length}d}'
+        value_string = dump_format.format(self=self, value=value, length=length)[:length]
+        return '{self.head}{value_string}{self.tail}'.format(self=self, value_string=value_string)
+
+    def loads(self, string):
+        self.value = int(self._parse(string))
+

--- a/pycoda/fields.py
+++ b/pycoda/fields.py
@@ -56,3 +56,37 @@ class StringField(Field):
     def loads(self, string):
         self.value = self._parse(string)
 
+
+class EmptyField(StringField):
+    def __init__(self, position, length, tag=None):
+        super(EmptyField, self).__init__(position, length, value=None, tag=tag)
+
+    def _regex(self):
+        return super(EmptyField, self)._regex()
+
+    def _parse(self, string):
+        return super(EmptyField, self)._parse(string)
+
+    def dumps(self):
+        return super(EmptyField, self).dumps()
+
+    def loads(self, string):
+        super(EmptyField, self).loads(string)
+
+
+class ZeroesField(StringField):
+    def __init__(self, position, length, tag=None):
+        super(ZeroesField, self).__init__(position, length, tag=tag, pad='0')
+
+    def _regex(self):
+        return super(ZeroesField, self)._regex()
+
+    def _parse(self, string):
+        return super(ZeroesField, self)._parse(string)
+
+    def dumps(self):
+        return super(ZeroesField, self).dumps()
+
+    def loads(self, string):
+        super(ZeroesField, self).loads(string)
+

--- a/pycoda/fields.py
+++ b/pycoda/fields.py
@@ -1,2 +1,58 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+
+import re
+from abc import ABCMeta, abstractmethod
+
+from six import with_metaclass
+
+
+class Field(with_metaclass(ABCMeta, object)):
+    def __init__(self, position, length, value=None, tag=None):
+        self.position = position
+        self.length = length
+        self.value = value
+        self.tag = tag
+
+    @abstractmethod
+    def _regex(self):
+        """Regular expression used in loading the value from a string"""
+
+    def _parse(self, string):
+        """Find match with regex and return if found"""
+        match = re.match(self._regex(), string)
+        if match is None:
+            raise ValueError('Specified string does not match field regex')
+        return match.group('value')
+
+    @abstractmethod
+    def dumps(self):
+        """Dump the value in the format such it can be picked up elsewhere"""
+
+    @abstractmethod
+    def loads(self, string):
+        """Parse value from given string, using the field's available regex"""
+
+
+class StringField(Field):
+    def __init__(self, position, length, value=None, tag=None,
+                 pad='', align='<'):
+        super(StringField, self).__init__(position, length,
+                                          value=value, tag=tag)
+        self.pad = pad
+        self.align = align
+
+    def _regex(self):
+        return r'^(?P<value>[\w\s]{{{self.length}}})$'.format(self=self)
+
+    def _parse(self, string):
+        return super(StringField, self)._parse(string)
+
+    def dumps(self):
+        value = self.value if self.value else ''
+        dump_format = '{value:{self.pad}{self.align}{self.length}s}'
+        return dump_format.format(self=self, value=value)[:self.length]
+
+    def loads(self, string):
+        self.value = self._parse(string)
+

--- a/pycoda/fields.py
+++ b/pycoda/fields.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 import re
 from abc import ABCMeta, abstractmethod
+from datetime import datetime
 
 from six import with_metaclass
 
@@ -117,3 +118,26 @@ class NumericField(StringField):
     def loads(self, string):
         self.value = int(self._parse(string))
 
+
+class DateField(StringField):
+    def __init__(self, position, length=6, value=None, tag=None,
+                 pad='', align='<', date_format='%d%m%y'):
+        super(DateField, self).__init__(position, length, value=value, tag=tag,
+                                        pad=pad, align=align)
+        self.date_format = date_format
+
+    def _regex(self):
+        return r'^(?P<value>\d{{{self.length}}})$'.format(self=self)
+
+    def _parse(self, string):
+        return super(DateField, self)._parse(string)
+
+    def dumps(self):
+        if self.value is None:
+            raise ValueError('No valid date value available')
+        dump_format = '{self.value:{self.date_format}}'
+        return dump_format.format(self=self)[:self.length]
+
+    def loads(self, string):
+        date_string = self._parse(string)
+        self.value = datetime.strptime(date_string, self.date_format).date()

--- a/pycoda/records.py
+++ b/pycoda/records.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from pycoda.fields import NumericField, StringField, ZeroesField, DateField, EmptyField
+
+
+class Record(object):
+    def __init__(self):
+        self._fields = ()
+
+    def dumps(self):
+        return ''.join(field.dumps() for field in self._fields)
+
+    def loads(self, string):
+        for field in self._fields:
+            field.loads(string[field.position:field.position + field.length])
+
+
+class InitialRecord(Record):
+    RECORD_IDENTIFICATION = 0
+    APPLICATION_CODE = '05'
+    VERSION_CODE = 2
+
+    def __init__(self,
+                 creation_date=None,
+                 bank_identification_number=None,
+                 duplicate_code=None,
+                 reference=None,
+                 addressee=None,
+                 bic=None,
+                 account_holder_reference=None,
+                 free=None,
+                 transaction_reference=None,
+                 related_reference=None,):
+        super(Record, self).__init__()
+
+        self._identification_field = NumericField(0, 1, value=InitialRecord.RECORD_IDENTIFICATION)
+        self._zeroes_field = ZeroesField(1, 4)
+        self._creation_date_field = DateField(5, 6, value=creation_date)
+        self._bank_identification_number_field = NumericField(11, 3,
+            value=bank_identification_number, pad=0)
+        self._application_code_field = StringField(14, 2, value=InitialRecord.APPLICATION_CODE)
+        self._duplicate_field = StringField(16, 1, value=duplicate_code)
+        self._empty_field0 = EmptyField(17, 7)
+        self._reference_field = StringField(24, 10, value=reference)
+        self._addressee_field = StringField(34, 26, value=addressee)
+        self._bic_field = StringField(60, 11, value=bic)
+        self._account_holder_reference_field = NumericField(71, 11, value=account_holder_reference,
+                                                            pad='0', align='>', head='0')
+        self._empty_field1 = EmptyField(82, 1)
+        self._free_field = StringField(83, 5, value=free)
+        self._transaction_reference_field = StringField(88, 16,
+            value=transaction_reference, tag='20/1')
+        self._related_reference_field = StringField(104, 16,
+            value=related_reference, tag='21/1')
+        self._empty_field2 = EmptyField(120, 7)
+        self._version_code_field = NumericField(127, 1, value=InitialRecord.VERSION_CODE)
+
+        self._fields = (
+            self._identification_field,
+            self._zeroes_field,
+            self._creation_date_field,
+            self._bank_identification_number_field,
+            self._application_code_field,
+            self._duplicate_field,
+            self._empty_field0,
+            self._reference_field,
+            self._addressee_field,
+            self._bic_field,
+            self._account_holder_reference_field,
+            self._empty_field1,
+            self._free_field,
+            self._transaction_reference_field,
+            self._related_reference_field,
+            self._empty_field2,
+            self._version_code_field,
+        )
+
+    def dumps(self):
+        return super(InitialRecord, self).dumps()
+
+    def loads(self, string):
+        super(InitialRecord, self).loads(string)
+
+    def creation_date(self):
+        return self._creation_date_field.value
+
+    def bank_identification_number(self):
+        return self._bank_identification_number_field.value
+
+    def is_duplicate(self):
+        return self._duplicate_field.value == 'D'
+
+    def reference(self):
+        return self._reference_field.value
+
+    def addressee(self):
+        return self._addressee_field.value
+
+    def bic(self):
+        return self._bic_field.value
+
+    def account_holder_reference(self):
+        return self._account_holder_reference_field.value
+
+    def free(self):
+        return self._free_field.value
+
+    def transaction_reference(self):
+        return self._transaction_reference_field.value
+
+    def related_reference(self):
+        return self._related_reference_field.value

--- a/pycoda/tests/__init__.py
+++ b/pycoda/tests/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals

--- a/pycoda/tests/test_fields.py
+++ b/pycoda/tests/test_fields.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals

--- a/pycoda/tests/test_fields.py
+++ b/pycoda/tests/test_fields.py
@@ -129,3 +129,35 @@ class StringFieldTest(TestCase):
         field = StringField(0, 3, pad=0)
         assert field.dumps() == '000'
 
+
+class EmptyFieldTest(TestCase):
+    def test_loads(self):
+        field = EmptyField(0, 4)
+        field.loads('    ')
+        assert field.value == '    '
+
+    def test_dumps(self):
+        field = EmptyField(0, 4)
+        assert field.dumps() == '    '
+
+    def test_load_from_dumps(self):
+        field = EmptyField(0, 4)
+        field.loads(field.dumps())
+        assert field.value == '    '
+
+
+class ZeroesFieldTest(TestCase):
+    def test_loads(self):
+        field = ZeroesField(0, 3)
+        field.loads('000')
+        assert field.value == '000'
+
+    def test_dumps(self):
+        field = ZeroesField(0, 10)
+        assert field.dumps() == '0' * 10
+
+    def test_loads_from_dumps(self):
+        field = StringField(0, 3)
+        field.loads(field.dumps())
+        assert field.value == '   '
+

--- a/pycoda/tests/test_fields.py
+++ b/pycoda/tests/test_fields.py
@@ -1,2 +1,131 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+
+from unittest import TestCase
+
+from pycoda.fields import (NumericField, StringField, ZeroesField, DateField, EmptyField)
+
+
+class StringFieldTest(TestCase):
+    def test_dumps(self):
+        field = StringField(0, 3, value='foo')
+        assert field.dumps() == 'foo'
+
+    def test_loads(self):
+        field = StringField(0, 3)
+        field.loads('foo')
+        assert field.value == 'foo'
+
+    def test_loads_dumps(self):
+        field = StringField(0, 3)
+        field.loads('foo')
+        assert field.dumps() == 'foo'
+
+    def test_loads_from_dumps(self):
+        field = StringField(0, 3, value='foo')
+        field.loads(field.dumps())
+        assert field.value == 'foo'
+
+    def test_new_field_from_dumps(self):
+        field = StringField(0, 3, value='foo')
+        new_field = StringField(0, 3, field.dumps())
+        assert new_field.value == 'foo'
+
+    def test_init_length_shorter_than_value(self):
+        field = StringField(0, 2, value='foo')
+        assert field.value == 'foo'
+
+    def test_init_length_longer_than_value(self):
+        field = StringField(0, 4, value='foo')
+        assert field.value == 'foo'
+
+    def test_init_empty_value(self):
+        field = StringField(0, 1, value=' ')
+        assert field.value == ' '
+
+    def test_init_leading_space(self):
+        field = StringField(0, 4, value=' foo')
+        assert field.value == ' foo'
+
+    def test_init_trailing_space(self):
+        field = StringField(0, 4, value='foo ')
+        assert field.value == 'foo '
+
+    def test_loads_length_shorter_than_value(self):
+        field = StringField(0, 2)
+        with self.assertRaises(ValueError):
+            field.loads('foo')
+
+    def test_loads_length_longer_than_value(self):
+        field = StringField(0, 4)
+        with self.assertRaises(ValueError):
+            field.loads('foo')
+
+    def test_loads_empty_string(self):
+        field = StringField(0, 1)
+        field.loads(' ')
+        assert field.value == ' '
+
+    def test_loads_leading_space(self):
+        field = StringField(0, 4)
+        field.loads(' foo')
+        assert field.value == ' foo'
+
+    def test_loads_trailing_space(self):
+        field = StringField(0, 4)
+        field.loads('foo ')
+        assert field.value == 'foo '
+
+    def test_loads_with_spaces(self):
+        field = StringField(0, 11)
+        field.loads('foo bar qux')
+        assert field.value == 'foo bar qux'
+
+    def test_dumps_length_shorter_than_value(self):
+        field = StringField(0, 2, value='foo')
+        assert field.dumps() == 'fo'
+
+    def test_dumps_length_longer_than_value(self):
+        field = StringField(0, 4, value='foo')
+        assert field.dumps() == 'foo '
+
+    def test_dumps_empty_string(self):
+        field = StringField(0, 1, value=' ')
+        assert field.dumps() == ' '
+
+    def test_dumps_empty_value(   self):
+        field = StringField(0, 3)
+        assert field.dumps() == '   '
+
+    def test_dumps_leading_space(self):
+        field = StringField(0, 4, value=' foo')
+        assert field.dumps() == ' foo'
+
+    def test_dumps_trailing_space(self):
+        field = StringField(0, 4, value= 'foo ')
+        assert field.dumps() == 'foo '
+
+    def test_dumps_init_none_value(self):
+        field = StringField(0, 3)
+        assert field.dumps() == '   '
+
+    def test_dumps_align_left(self):
+        field = StringField(0, 4, value='foo', pad=' ', align='<')
+        assert field.dumps() == 'foo '
+
+    def test_dumps_align_right(self):
+        field = StringField(0, 4, value='foo', pad=' ', align='>')
+        assert field.dumps() == ' foo'
+
+    def test_dumps_align_left_pad_zero(self):
+        field = StringField(0, 6, value='foo', pad='0', align='<')
+        assert field.dumps() == 'foo000'
+
+    def test_dumps_align_right_pad_zero(self):
+        field = StringField(0, 6, value='foo', pad='0', align='>')
+        assert field.dumps() == '000foo'
+
+    def test_dumps_pad_zero(self):
+        field = StringField(0, 3, pad=0)
+        assert field.dumps() == '000'
+

--- a/pycoda/tests/test_fields.py
+++ b/pycoda/tests/test_fields.py
@@ -161,3 +161,94 @@ class ZeroesFieldTest(TestCase):
         field.loads(field.dumps())
         assert field.value == '   '
 
+
+class NumericFieldTest(TestCase):
+    def test_dumps_length_value_equal(self):
+        field = NumericField(0, 1, value=1)
+        assert field.dumps() == '1'
+
+    def test_dumps_length_longer_than_value(self):
+        field = NumericField(0, 2, value=1)
+        assert field.dumps() == '1 '
+
+    def test_dumps_length_shorter_than_value(self):
+        field = NumericField(0, 1, value=12)
+        assert field.dumps() == '1'
+
+    def test_loads_length_string_equal(self):
+        field = NumericField(0, 10)
+        field.loads('1234567890')
+        assert field.value == 1234567890
+
+    def test_loads_length_longer_than_string(self):
+        field = NumericField(0, 2)
+        with self.assertRaises(ValueError):
+            field.loads('1')
+
+    def test_loads_trailing_space(self):
+        field = NumericField(0, 2)
+        field.loads('1 ')
+        assert field.value == 1
+
+    def test_loads_leading_space(self):
+        field = NumericField(0, 2)
+        field.loads(' 1')
+        assert field.value == 1
+
+    def test_loads_length_shorter_than_string(self):
+        field = NumericField(0, 1)
+        with self.assertRaises(ValueError):
+            field.loads('11')
+
+    def test_loads_dumps_equal_same_length(self):
+        field = NumericField(0, 10)
+        field.loads('9876543210')
+        assert field.dumps() == '9876543210'
+
+    def test_loads_dumps_equal_shorter(self):
+        field = NumericField(0, 10)
+        field.loads('12345     ')
+        assert field.dumps() == '12345     '
+
+    def test_loads_from_dumps(self):
+        field = NumericField(0, 6, value=123)
+        field.loads(field.dumps())
+        assert field.value == 123
+
+    def test_loads_leading_head(self):
+        field = NumericField(0, 6, head='abc')
+        field.loads('abc' + '123')
+        assert field.value == 123
+
+    def test_loads_trailing_tail(self):
+        field = NumericField(0, 6, tail='abc')
+        field.loads('123' + 'abc')
+        assert field.value == 123
+
+    def test_loads_leading_head_and_trailing_tail(self):
+        field = NumericField(0, 12, head='000', tail='QWERTY')
+        field.loads('000123QWERTY')
+        assert field.value == 123
+
+    def test_dumps_leading_head(self):
+        field = NumericField(0, 6, value=456, head='lol')
+        assert field.dumps() == 'lol456'
+
+    def test_dumps_trailing_tail(self):
+        field = NumericField(0, 6, value=456, tail='lol')
+        assert field.dumps() == '456lol'
+
+    def test_dumps_leading_head_trailing_tail(self):
+        field = NumericField(0, 16, value=12357, head='asddfg', tail='zxcvb')
+        assert field.dumps() == 'asddfg12357zxcvb'
+
+    def test_loads_head_align_pad(self):
+        field = NumericField(0, 11, head='0', pad='0', align='>')
+        field.loads('00886946917')
+        assert field.value == 886946917
+
+    def test_loads_dumps_head_align_pad(self):
+        field = NumericField(0, 11, head='0', pad='0', align='>')
+        field.loads('00886946917')
+        assert field.dumps() == '00886946917'
+

--- a/pycoda/tests/test_fields.py
+++ b/pycoda/tests/test_fields.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+from datetime import date
 from unittest import TestCase
 
 from pycoda.fields import (NumericField, StringField, ZeroesField, DateField, EmptyField)
@@ -252,3 +253,41 @@ class NumericFieldTest(TestCase):
         field.loads('00886946917')
         assert field.dumps() == '00886946917'
 
+
+class DateFieldTest(TestCase):
+    def test_dumps_empty(self):
+        field = DateField(0)
+        with self.assertRaises(ValueError):
+            field.dumps()
+
+    def test_loads(self):
+        field = DateField(0)
+        field.loads('280386')
+        assert field.value == date(1986, 3, 28)
+
+    def test_dumps(self):
+        field = DateField(0, value=date(1986, 3, 28))
+        assert field.dumps() == '280386'
+
+    def test_loads_21st_century(self):
+        field = DateField(0)
+        field.loads('050417')
+        assert field.value == date(2017, 4, 5)
+
+    def test_dumps_21st_century(self):
+        field = DateField(0, value=date(2017, 4, 5))
+        assert field.dumps() == '050417'
+
+    def test_loads_from_dumps(self):
+        field = DateField(0, value=date(1986, 3, 28))
+        field.loads(field.dumps())
+        assert field.value == date(1986, 3, 28)
+
+    def test_dumps_alternate_date_format(self):
+        field = DateField(0, 8, value=date(2017, 4, 5), date_format='%Y%m%d')
+        assert field.dumps() == '20170405'
+
+    def test_loads_alternate_date_format(self):
+        field = DateField(0, 8, date_format='%Y%m%d')
+        field.loads('20170405')
+        assert field.value == date(2017, 4, 5)

--- a/pycoda/tests/test_records.py
+++ b/pycoda/tests/test_records.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from datetime import date
+from unittest import TestCase
+
+from pycoda.records import InitialRecord
+
+
+
+FAIL_PAYMENT_RAW = """0000019091672505        00417969  VIKINGCO NV               KREDBEBB   00886946917 00000                                       2
+12256BE02737026917240                  EUR0000005020346650150916VIKINGCO NV               KBC-Bedrijfsrekening               119
+2100220000AQQE12627 BHKDGLGTESC0000000000000460140916105500000                                                     14091625611 0
+2200220000                                                     C20160903040112-{collection_file_id}F                                         0 0
+2100230105AQPJ06455 SDDBCDBCRFN1000000000022000ddmmyy505500001127ddmmyy310BE02ZZZ0886946917                  M13178ddmmyy25601 0
+22000100270U332767051                  Direct Debit payment CLPCLP1-trtrtrtr                                    2MS03        1 0
+2300230105BEBEBEBEBEBEBEBE                     mvstagingpos20iiiiiiiiiiii Test    1-trtrtrtr                            0    0 1
+3100230106AQPJ06455 SDDBCDBCRFN505500001001mvstagingpos20iiiiiiiiiiii Test                                                   0 0
+9               019320000000000482010000000112273820                                                                           2
+"""  # nopep8
+
+SUCCESS_PAYMENT_RAW = """0000019091672505        00417969  VIKINGCO NV               KREDBEBB   00886946917 00000                                       2
+12256BE02737026917240                  EUR0000005020346650150916VIKINGCO NV               KBC-Bedrijfsrekening               119
+2100220000AQQE12627 BHKDGLGTESC0000000000000460140916105500000                                                     14091625611 0
+2200220000                                                     C20160903040112-{collection_file_id}F                                         0 0
+2100230105AQPJ06455 SDDBCDBCRFN0000000000022000ddmmyy505500001127ddmmyy310BE02ZZZ0886946917                  M13178ddmmyy25601 0
+22000100270U332767051                  Direct Debit payment CLPCLP1-trtrtrtr                                                 1 0
+2300230105BEBEBEBEBEBEBEBE                     mvstagingpos20iiiiiiiiiiii Test    1-trtrtrtr                            0    0 1
+3100230106AQPJ06455 SDDBCDBCRFN505500001001mvstagingpos20iiiiiiiiiiii Test                                                   0 0
+9               019320000000000482010000000112273820                                                                           2
+"""  # nopep8
+
+SUCCESS_OGM_RAW = """0000019091672505        00417969  VIKINGCO NV               KREDBEBB   00886946917 00000                                       2
+12256BE02737026917240                  EUR0000005020346650150916VIKINGCO NV               KBC-Bedrijfsrekening               119
+2100220000AQQE12627 BHKDGLGTESC0000000000000460140916105500000                                                     14091625611 0
+2200220000                                                     C20160903040112-{collection_file_id}F                                         0 0
+2100060000CVYC01435BSCTOBAOVERS0000000000022000ddmmyy001500000+++TTT/TTTT/TTTTT+++                                 ddmmyy26401 0
+2200060000                                                                                        KREDBEBB                   1 0
+2300060000BE10734024724804                     PEETERS ALEXIA                                                                0 1
+3100060001CVYC01435BSCTOBAOVERS001500001001PEETERS ALEXIA                                                                    1 0
+9               019320000000000482010000000112273820                                                                           2
+"""  # nopep8
+
+
+class InitialRecordTest(TestCase):
+    def test_field_positions_are_consecutive(self):
+        record = InitialRecord()
+        for field, next_field in zip(record._fields[:-1], record._fields[1:]):
+            assert field.position + field.length == next_field.position
+
+    def test_example_loads_dumps_success_payment(self):
+        record = InitialRecord()
+        record.loads(SUCCESS_PAYMENT_RAW[:128])
+        assert record.dumps() == SUCCESS_PAYMENT_RAW[:128]
+
+    def test_example_loads_dumps_fail_payment(self):
+        record = InitialRecord()
+        record.loads(FAIL_PAYMENT_RAW[:128])
+        assert record.dumps() == FAIL_PAYMENT_RAW[:128]
+
+    def test_example_loads_dumps_success_ogm(self):
+        record = InitialRecord()
+        record.loads(SUCCESS_OGM_RAW[:128])
+        assert record.dumps() == SUCCESS_OGM_RAW[:128]
+
+    def test_creation_date(self):
+        record = InitialRecord(creation_date=date(2017, 3, 28))
+        assert record.creation_date() == date(2017, 3, 28)
+
+    def test_bank_identification_number(self):
+        record = InitialRecord(bank_identification_number=725)
+        assert record.bank_identification_number() == 725
+
+    def test_duplicate_code_true(self):
+        record = InitialRecord(duplicate_code='D')
+        assert record.is_duplicate()
+
+    def test_duplicate_code_false(self):
+        record = InitialRecord(duplicate_code=' ')
+        assert not record.is_duplicate()
+
+    def test_reference(self):
+        record = InitialRecord(reference='00417969')
+        assert record.reference() == '00417969'
+
+    def test_addressee(self):
+        record = InitialRecord(addressee='Unleashed NV')
+        assert record.addressee() == 'Unleashed NV'
+
+    def test_bic(self):
+        record = InitialRecord(bic='KREDBEBB')
+        assert record.bic() == 'KREDBEBB'
+
+    def test_account_holder_reference(self):
+        record = InitialRecord(account_holder_reference='00886946917')
+        assert record.account_holder_reference() == '00886946917'
+
+    def test_free(self):
+        record = InitialRecord(free='12345')
+        assert record.free() == '12345'
+
+    def test_transaction_reference(self):
+        record = InitialRecord(transaction_reference='abc123xyz')
+        assert record.transaction_reference() == 'abc123xyz'
+
+    def test_related_reference(self):
+        record = InitialRecord(related_reference='qwerty')
+        assert record.related_reference() == 'qwerty'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+appdirs==1.4.3
+packaging==16.8
+pyparsing==2.2.0
+six==1.10.0


### PR DESCRIPTION
Closes #2. Adds possibility to read / write initial record for CODA files.

First, the structure for reading / write individual fields is added. A field can has the following attributes:
  - position: start position of string
  - length: max width of the string
  - value
  - tag: optional, specified by CODA standard

Two methods are imposed: `dumps` and `loads`:
  - `dumps`: print the value in the format from the attributes
  - `loads`: load the value from the format in the attributes

For the `loads` method, a `_regex` and `_parse` method is available that shall be implemented by all possible field types.

Other field types include `StringField`, `EmptyField`, `ZeroesField`, `NumericField` and `DateField`.

Secondly, a `Record` class is added that is a container to all sorts of fields. Using the power of `dumps` and `loads` of the fields, it can do the same thing fairly trivially from a record-level.

Here we implement the initial record.

Further records will need to be implemented to process an entire CODA file.