### PR TITLE
Old balance record

### DIFF
--- a/pycoda/fields.py
+++ b/pycoda/fields.py
@@ -44,7 +44,7 @@ class StringField(Field):
         self.align = align
 
     def _regex(self):
-        return r'^(?P<value>[\w\s]{{{self.length}}})$'.format(self=self)
+        return r'^(?P<value>[\w\s\-]{{{self.length}}})$'.format(self=self)
 
     def _parse(self, string):
         return super(StringField, self)._parse(string)

--- a/pycoda/records.py
+++ b/pycoda/records.py
@@ -111,3 +111,49 @@ class InitialRecord(Record):
 
     def related_reference(self):
         return self._related_reference_field.value
+
+
+class OldBalanceRecord(Record):
+    RECORD_IDENTIFICATION = 1
+
+    def __init__(self,
+                 account_structure=None,
+                 serial_number=None,
+                 account_number=None,
+                 balance_sign=None,
+                 old_balance=None,
+                 balance_date=None,
+                 account_holder_name=None,
+                 account_description=None,
+                 bank_statement_serial_number=None):
+        super(OldBalanceRecord, self).__init__()
+
+        self._identification_field = NumericField(0, 1, value=OldBalanceRecord.RECORD_IDENTIFICATION)
+        self._account_structure_field = NumericField(1, 1, value=account_structure)
+        self._serial_number_field = NumericField(2, 3, value=serial_number, tag='28c/1')
+        self._account_number_field = StringField(5, 37, value=account_number)
+        self._balance_sign_field = NumericField(42, 1, value=balance_sign, tag='60F/1')
+        self._old_balance_field = NumericField(43, 15, value=old_balance, tag='60F/4', pad='0', align='>')
+        self._balance_date_field = DateField(58, 6, value=balance_date, tag='60F/2')
+        self._account_holder_name_field = StringField(64, 26, value=account_holder_name)
+        self._account_description_field = StringField(90, 35, value=account_description)
+        self._bank_statement_serial_number_field = NumericField(125, 3, value=bank_statement_serial_number,
+                                                                pad=0, align='>')
+        self._fields = (
+            self._identification_field,
+            self._account_structure_field,
+            self._serial_number_field,
+            self._account_number_field,
+            self._balance_sign_field,
+            self._old_balance_field,
+            self._balance_date_field,
+            self._account_holder_name_field,
+            self._account_description_field,
+            self._bank_statement_serial_number_field,
+        )
+
+    def dumps(self):
+        return super(OldBalanceRecord, self).dumps()
+
+    def loads(self, string):
+        super(OldBalanceRecord, self).loads(string)

--- a/pycoda/records.py
+++ b/pycoda/records.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from pycoda.fields import NumericField, StringField, ZeroesField, DateField, EmptyField
+from pycoda.fields import NumericField, StringField, ZeroesField, DateField, EmptyField, BalanceField
 
 
 class Record(object):
@@ -133,7 +133,7 @@ class OldBalanceRecord(Record):
         self._serial_number_field = NumericField(2, 3, value=serial_number, tag='28c/1')
         self._account_number_field = StringField(5, 37, value=account_number)
         self._balance_sign_field = NumericField(42, 1, value=balance_sign, tag='60F/1')
-        self._old_balance_field = NumericField(43, 15, value=old_balance, tag='60F/4', pad='0', align='>')
+        self._old_balance_field = BalanceField(43, value=old_balance, tag='60F/4')
         self._balance_date_field = DateField(58, 6, value=balance_date, tag='60F/2')
         self._account_holder_name_field = StringField(64, 26, value=account_holder_name)
         self._account_description_field = StringField(90, 35, value=account_description)

--- a/pycoda/tests/test_fields.py
+++ b/pycoda/tests/test_fields.py
@@ -4,7 +4,9 @@ from __future__ import unicode_literals
 from datetime import date
 from unittest import TestCase
 
-from pycoda.fields import (NumericField, StringField, ZeroesField, DateField, EmptyField)
+from decimal import Decimal
+
+from pycoda.fields import (NumericField, StringField, ZeroesField, DateField, EmptyField, BalanceField)
 
 
 class StringFieldTest(TestCase):
@@ -310,3 +312,24 @@ class DateFieldTest(TestCase):
         field = DateField(0, 8, date_format='%Y%m%d')
         field.loads('20170405')
         assert field.value == date(2017, 4, 5)
+
+
+class BalanceFieldTest(TestCase):
+    def test_loads(self):
+        field = BalanceField(0)
+        field.loads('000000034568797')
+        assert field.value == Decimal('34568.797')
+
+    def test_dumps(self):
+        field = BalanceField(0, value=Decimal('65536.128'))
+        assert field.dumps() == '000000065536128'
+
+    def test_loads_from_dumps(self):
+        field = BalanceField(0, value=Decimal('65536.128'))
+        field.loads(field.dumps())
+        assert field.value == Decimal('65536.128')
+
+    def test_loads_from_dumps_higher_precision(self):
+        field = BalanceField(0, value=Decimal('65536.1024'))
+        field.loads(field.dumps())
+        assert field.value == Decimal('655361.024')

--- a/pycoda/tests/test_fields.py
+++ b/pycoda/tests/test_fields.py
@@ -130,6 +130,25 @@ class StringFieldTest(TestCase):
         field = StringField(0, 3, pad=0)
         assert field.dumps() == '000'
 
+    def test_loads_hyphen(self):
+        field = StringField(0, 11)
+        field.loads('some-string')
+        assert field.value == 'some-string'
+
+    def test_dumps_hyphen(self):
+        field = StringField(0, 7, value='foo-bar')
+        assert field.dumps() == 'foo-bar'
+
+    def test_loads_from_dumps_hyphen(self):
+        field = StringField(0, 7, value='foo-bar')
+        field.loads(field.dumps())
+        assert field.value == 'foo-bar'
+
+    def test_loads_extra_space_hyphen(self):
+        field = StringField(0, 14)
+        field.loads('some-string   ')
+        assert field.value == 'some-string   '
+
 
 class EmptyFieldTest(TestCase):
     def test_loads(self):

--- a/pycoda/tests/test_records.py
+++ b/pycoda/tests/test_records.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from datetime import date
 from unittest import TestCase
 
-from pycoda.records import InitialRecord
+from pycoda.records import InitialRecord, OldBalanceRecord
 
 
 
@@ -106,3 +106,25 @@ class InitialRecordTest(TestCase):
     def test_related_reference(self):
         record = InitialRecord(related_reference='qwerty')
         assert record.related_reference() == 'qwerty'
+
+
+class OldBalanceRecordTest(TestCase):
+    def test_field_positions_are_consecutive(self):
+        record = OldBalanceRecord()
+        for field, next_field in zip(record._fields[:-1], record._fields[1:]):
+            assert field.position + field.length == next_field.position
+
+    def test_example_loads_dumps_success_payment(self):
+        record = OldBalanceRecord()
+        record.loads(SUCCESS_PAYMENT_RAW[129:257])
+        assert record.dumps() == SUCCESS_PAYMENT_RAW[129:257]
+
+    def test_example_loads_dumps_fail_payment(self):
+        record = OldBalanceRecord()
+        record.loads(FAIL_PAYMENT_RAW[129:257])
+        assert record.dumps() == FAIL_PAYMENT_RAW[129:257]
+
+    def test_example_loads_dumps_success_ogm(self):
+        record = OldBalanceRecord()
+        record.loads(SUCCESS_OGM_RAW[129:257])
+        assert record.dumps() == SUCCESS_OGM_RAW[129:257]


### PR DESCRIPTION
Closes #3 : implementation of old balance record (record number 1).

Additionally, added option to load `StringField`s with hyphens. Adds a `BalanceField` specifically for any kind of balance as used throughout CODA.