### PR TITLE
Extends StringField to be able to read more chars

### DIFF
--- a/pycoda/fields.py
+++ b/pycoda/fields.py
@@ -45,7 +45,8 @@ class StringField(Field):
         self.align = align
 
     def _regex(self):
-        return r'^(?P<value>[\w\s\-]{{{self.length}}})$'.format(self=self)
+        return (r'^(?P<value>[\w\s\-\&\.\/\(\)\'\,]'
+                r'{{{self.length}}})$').format(self=self)
 
     def _parse(self, string):
         return super(StringField, self)._parse(string)

--- a/pycoda/records.py
+++ b/pycoda/records.py
@@ -210,7 +210,7 @@ class TransactionRecord(Record):
         self._balance_date_field = DateField(
             47, 6, value=balance_date, tag='61/1')
         self._transaction_code_field = NumericField(
-            53, 8, value=transaction_code, tag='61/6')
+            53, 8, value=transaction_code, pad='0', align='>', tag='61/6')
         self._reference_type_field = NumericField(61, 1, value=reference_type)
         self._reference_field = StringField(
             62, 53, value=reference, tag='61/9')

--- a/pycoda/tests/test_fields.py
+++ b/pycoda/tests/test_fields.py
@@ -151,6 +151,36 @@ class StringFieldTest(TestCase):
         field.loads('some-string   ')
         assert field.value == 'some-string   '
 
+    def test_loads_from_dumps_ampersand(self):
+        field = StringField(0, 11)
+        field.loads('drum & bass')
+        assert field.value == 'drum & bass'
+
+    def test_loads_from_dumps_dot(self):
+        field = StringField(0, 7)
+        field.loads('web 2.0')
+        assert field.value == 'web 2.0'
+
+    def test_loads_from_dumps_forward_slash(self):
+        field = StringField(0, 5)
+        field.loads('A / B')
+        assert field.value == 'A / B'
+
+    def test_loads_from_dumps_forward_braces(self):
+        field = StringField(0, 13)
+        field.loads('(hello world)')
+        assert field.value == '(hello world)'
+
+    def test_loads_from_dumps_forward_accent(self):
+        field = StringField(0, 7)
+        field.loads("d'hondt")
+        assert field.value == "d'hondt"
+
+    def test_loads_from_dumps_forward_comma(self):
+        field = StringField(0, 12)
+        field.loads('ebony, ivory')
+        assert field.value == 'ebony, ivory'
+
 
 class EmptyFieldTest(TestCase):
     def test_loads(self):

--- a/pycoda/tests/test_records.py
+++ b/pycoda/tests/test_records.py
@@ -90,8 +90,8 @@ class OldBalanceRecordTest(TestCase):
 
 
 class TransactionRecordTest(TestCase):
-    RAW = ('2100220000AQQE12627 BHKDGLGTESC0000000000000460140916105500000  '
-           '                                                   14091625611 0')
+    RAW = ('2100010000OL1002OFFASCTOVSOVERS000000000001000018081600150000110'
+           '1048573874287                                      18081623001 0')
 
     def setUp(self):
         self.record = TransactionRecord()


### PR DESCRIPTION
Extends the regex such that more characters are available to be read in
the StringField class. Popped up after reading an actual CODA file.
Tests updated accordingly.