### PR TITLE
Don't output negative balance fields

### DIFF
--- a/pycoda/fields.py
+++ b/pycoda/fields.py
@@ -180,7 +180,8 @@ class BalanceField(Field):
             value_tuple = Decimal(0).as_tuple()
         else:
             value_tuple = self.value.as_tuple()
-        shifted = Decimal((value_tuple.sign, value_tuple.digits, 0))
+        # Always use a positive sign here
+        shifted = Decimal((0, value_tuple.digits, 0))
         dump_format = "{shifted:{self.pad}{self.LENGTH}f}"
         return dump_format.format(self=self, shifted=shifted)
 

--- a/pycoda/tests/test_fields.py
+++ b/pycoda/tests/test_fields.py
@@ -364,6 +364,10 @@ class BalanceFieldTest(TestCase):
         field = BalanceField(0, value=Decimal("65536.128"))
         assert field.dumps() == "000000065536128"
 
+    def test_dumps_negative(self):
+        field = BalanceField(0, value=Decimal("-65536.128"))
+        assert field.dumps() == "000000065536128"
+
     def test_loads_from_dumps(self):
         field = BalanceField(0, value=Decimal("65536.128"))
         field.loads(field.dumps())


### PR DESCRIPTION
When outputting the value for a negative balance field, it would include
a minus `-` sign. CODA doesn't do this; instead it has specific fields
to output the balance fields signs.

Idea for an additional extension: have the record managing the fields output
the correct values (sign / balance field). This complicates the overall
solution though.
